### PR TITLE
Replace native confirms with themed modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -336,6 +336,25 @@
         </div>
     </div>
 
+    <!-- MODAL DE CONFIRMAÇÃO GLOBAL -->
+    <div id="confirm-modal"
+        class="hidden fixed inset-0 bg-black bg-opacity-75 flex items-center justify-center p-4 z-50">
+        <div class="bg-gray-800 rounded-lg p-6 max-w-md w-full text-left">
+            <h2 id="confirm-title" class="text-2xl font-bold text-indigo-400 mb-3">Confirmação</h2>
+            <p id="confirm-message" class="text-gray-300"></p>
+            <div class="flex flex-col sm:flex-row gap-3 mt-6">
+                <button id="confirm-cancel-btn"
+                    class="w-full bg-gray-600 hover:bg-gray-700 text-white font-bold py-2 px-4 rounded-lg focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-900 focus:ring-gray-500 transition-colors">
+                    Cancelar
+                </button>
+                <button id="confirm-confirm-btn"
+                    class="w-full bg-indigo-600 hover:bg-indigo-700 text-white font-bold py-2 px-4 rounded-lg focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-900 focus:ring-indigo-500 transition-colors">
+                    Confirmar
+                </button>
+            </div>
+        </div>
+    </div>
+
 
     <script src="js/app.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- add a reusable confirmation modal component styled like the rest of the app
- replace browser confirm dialogs with the themed modal for archiving months, ending workouts, and managing history entries

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d05555b9f08327b6309b8754685aea