### PR TITLE
Add UI for custom exercises with persistent storage

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,7 +63,13 @@
 
                         <!-- Metas Mensais -->
                         <div class="bg-gray-900/50 p-4 rounded-lg">
-                            <h3 class="font-bold text-lg text-gray-200 mb-3">Editar Metas Mensais</h3>
+                            <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between mb-3 gap-2">
+                                <h3 class="font-bold text-lg text-gray-200">Editar Metas Mensais</h3>
+                                <button id="add-exercise-btn" type="button"
+                                    class="text-sm bg-indigo-600 hover:bg-indigo-700 text-white font-bold py-1 px-3 rounded-md w-full sm:w-auto">
+                                    + Exercício
+                                </button>
+                            </div>
                             <div class="mb-4">
                                 <label class="block text-sm font-bold text-gray-300 mb-2">Dias no Mês</label>
                                 <div id="days-in-month-options"
@@ -252,6 +258,49 @@
                 class="w-full bg-indigo-600 hover:bg-indigo-700 text-white font-bold py-4 px-4 rounded-lg text-xl transition-all transform hover:scale-105 shadow-lg">
                 Treinar Novamente
             </button>
+        </div>
+    </div>
+
+    <!-- MODAL DE EXERCÍCIO PERSONALIZADO -->
+    <div id="exercise-modal"
+        class="hidden fixed inset-0 bg-black bg-opacity-75 flex items-center justify-center p-4 z-50">
+        <div class="bg-gray-800 rounded-lg p-6 max-w-md w-full text-left">
+            <h2 id="exercise-modal-title" class="text-2xl font-bold text-indigo-400 mb-4">Novo Exercício</h2>
+            <form id="exercise-form" class="space-y-4">
+                <div>
+                    <label for="exercise-name" class="block text-sm font-bold text-gray-300 mb-2">Nome do
+                        Exercício</label>
+                    <input type="text" id="exercise-name"
+                        class="w-full bg-gray-900 border border-gray-600 rounded-md p-2 focus:ring-2 focus:ring-indigo-500 focus:outline-none"
+                        required>
+                </div>
+                <div>
+                    <label for="exercise-type" class="block text-sm font-bold text-gray-300 mb-2">Tipo</label>
+                    <select id="exercise-type"
+                        class="w-full bg-gray-900 border border-gray-600 rounded-md p-2 focus:ring-2 focus:ring-indigo-500 focus:outline-none">
+                        <option value="reps">Repetições</option>
+                        <option value="time">Tempo (segundos)</option>
+                    </select>
+                </div>
+                <div>
+                    <label for="exercise-monthly-goal" class="block text-sm font-bold text-gray-300 mb-2">Meta
+                        Mensal</label>
+                    <input type="number" id="exercise-monthly-goal" min="1"
+                        class="w-full bg-gray-900 border border-gray-600 rounded-md p-2 focus:ring-2 focus:ring-indigo-500 focus:outline-none"
+                        required>
+                </div>
+                <p id="exercise-modal-error" class="text-sm text-red-400"></p>
+                <div class="flex gap-4 pt-2">
+                    <button id="cancel-exercise-btn" type="button"
+                        class="w-full bg-gray-600 hover:bg-gray-700 text-white font-bold py-2 px-4 rounded-lg">
+                        Cancelar
+                    </button>
+                    <button type="submit"
+                        class="w-full bg-indigo-600 hover:bg-indigo-700 text-white font-bold py-2 px-4 rounded-lg">
+                        Salvar Exercício
+                    </button>
+                </div>
+            </form>
         </div>
     </div>
 


### PR DESCRIPTION
## Summary
- persist a customExercises list in the saved data and merge it with the base exercises when configuring workouts
- update the setup panel to render combined exercises with edit/remove controls and adjust ordering handling
- add a modal form for creating custom exercises, hooking goal recalculation and progress updates on save

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d06a6e74348327b9a57028819fba0f