### PR TITLE
Add monthly overview to progress panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,6 +56,20 @@
                                         Treino Passado</button>
                                 </div>
                             </div>
+                            <div id="monthly-overview" class="grid grid-cols-1 sm:grid-cols-3 gap-3 mb-4">
+                                <div class="bg-gray-800/70 p-3 rounded-md text-center">
+                                    <p class="text-xs uppercase tracking-wider text-gray-400">Treinos registrados</p>
+                                    <p id="monthly-overview-days" class="text-2xl font-bold text-white mt-1">0</p>
+                                </div>
+                                <div class="bg-gray-800/70 p-3 rounded-md text-center">
+                                    <p class="text-xs uppercase tracking-wider text-gray-400">Exercícios concluídos</p>
+                                    <p id="monthly-overview-completed" class="text-2xl font-bold text-white mt-1">0/0</p>
+                                </div>
+                                <div class="bg-gray-800/70 p-3 rounded-md text-center">
+                                    <p class="text-xs uppercase tracking-wider text-gray-400">Dias restantes</p>
+                                    <p id="monthly-overview-remaining" class="text-2xl font-bold text-white mt-1">0</p>
+                                </div>
+                            </div>
                             <div id="monthly-progress-container" class="space-y-2 text-sm">
                                 <!-- Progresso será injetado aqui -->
                             </div>


### PR DESCRIPTION
## Summary
- add overview cards to the monthly progress panel highlighting training days, completed exercises and days remaining
- compute and update overview statistics alongside existing monthly progress rendering logic

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d072c56124832781f06bea12c24dc1