### PR TITLE
Clone archive snapshots before clearing history

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -261,9 +261,22 @@ document.addEventListener('DOMContentLoaded', async () => {
                     if (shouldArchive) {
                         if (!appData.archive) appData.archive = {};
                         const archiveKey = `${appData.currentChallenge.year}-${String(appData.currentChallenge.month).padStart(2, '0')}`;
+
+                        const cloneData = (value, fallback = {}) => {
+                            const source = value ?? fallback;
+                            if (typeof structuredClone === 'function') {
+                                try {
+                                    return structuredClone(source);
+                                } catch (error) {
+                                    console.warn('structuredClone failed, falling back to JSON clone.', error);
+                                }
+                            }
+                            return JSON.parse(JSON.stringify(source));
+                        };
+
                         appData.archive[archiveKey] = {
-                            monthlyGoals: appData.monthlyGoals,
-                            history: appData.history
+                            monthlyGoals: cloneData(appData.monthlyGoals, {}),
+                            history: cloneData(appData.history, {})
                         };
                         appData.history = {};
                         dataChanged = true;


### PR DESCRIPTION
## Summary
- deep clone monthly goals and history before storing archived months so later edits do not mutate snapshots
- use a clone helper that falls back to JSON serialization to preserve the structure consumed by history rendering

## Testing
- node <<'NODE'
const cloneData = (value, fallback = {}) => {
  const source = value ?? fallback;
  if (typeof structuredClone === 'function') {
    try {
      return structuredClone(source);
    } catch (error) {
      console.warn('structuredClone failed, falling back to JSON clone.', error);
    }
  }
  return JSON.parse(JSON.stringify(source));
};

const appData = {
  currentChallenge: { year: 2024, month: 4 },
  monthlyGoals: { a: 1, b: 2 },
  history: {
    '2024-04-01': [
      { timestamp: '2024-04-01T12:00:00Z', log: { a: 10, b: 20 } }
    ]
  },
  archive: {}
};

const archiveKey = `${appData.currentChallenge.year}-${String(appData.currentChallenge.month).padStart(2, '0')}`;
appData.archive[archiveKey] = {
  monthlyGoals: cloneData(appData.monthlyGoals, {}),
  history: cloneData(appData.history, {})
};

appData.history = {};
appData.monthlyGoals.a = 999;

console.log('Archive goals a:', appData.archive[archiveKey].monthlyGoals.a);
console.log('Archive history entries:', appData.archive[archiveKey].history['2024-04-01'][0].log);
NODE

------
https://chatgpt.com/codex/tasks/task_e_68d07976b6c083278aed359e45e3347d